### PR TITLE
Do not require sections unless in strict mode

### DIFF
--- a/openscad_docsgen/__init__.py
+++ b/openscad_docsgen/__init__.py
@@ -11,6 +11,7 @@ from .blocks import DocsGenParser, DocsGenException, errorlog
 
 def processFiles(
     files, docs_dir,
+    strict=False,
     test_only=False,
     force=False,
     gen_imgs=False,
@@ -36,7 +37,7 @@ def processFiles(
     if fail:
         sys.exit(-1)
 
-    docsgen = DocsGenParser()
+    docsgen = DocsGenParser(strict=strict)
     for infile in files:
         docsgen.parse_file(
             infile,
@@ -68,6 +69,8 @@ def main():
     parser = argparse.ArgumentParser(prog='openscad-docsgen')
     parser.add_argument('-D', '--docs-dir', default="docs",
                         help='The directory to put generated documentation in.')
+    parser.add_argument('-S', '--strict', action="store_true",
+                        help='If given, section blocks are required.')
     parser.add_argument('-T', '--test-only', action="store_true",
                         help="If given, don't generate images, but do try executing the scripts.")
     parser.add_argument('-f', '--force', action="store_true",
@@ -95,6 +98,7 @@ def main():
         processFiles(
             args.srcfile,
             docs_dir=args.docs_dir,
+            strict=args.strict,
             test_only=args.test_only,
             force=args.force,
             gen_imgs=not args.no_images,

--- a/openscad_docsgen/blocks.py
+++ b/openscad_docsgen/blocks.py
@@ -380,6 +380,11 @@ class SectionBlock(GenericBlock):
         super().__init__(title, subtitle, body, origin, parent=parent)
 
     def get_toc_lines(self, indent=4):
+        """
+        Return the markdown table of contents lines for the children in this
+        section. This is returned as a series of bullet points.
+        `indent` sets the level of indentation for the bullet points
+        """
         out = []
         for child in self.children:
             if isinstance(child, ItemBlock):
@@ -388,17 +393,25 @@ class SectionBlock(GenericBlock):
         return out
 
     def get_markdown(self, controller):
+        """
+        Return the markdown for this section. This includes the section
+        heading and the markdown for the children. To return only the
+        the markdown for the children see `get_childrens_markdown`
+        """
         out = []
         out.append("---")
         out.append("")
         out.append("## {}".format(mkdn_esc(str(self))))
         out.extend(self.get_markdown_body(controller))
         out.append("")
-        out += self.get_childrens_mardown(controller)
+        out += self.get_childrens_markdown(controller)
 
         return out
 
-    def get_childrens_mardown(self, controller):
+    def get_childrens_markdown(self, controller):
+        """
+        Return the markdown for just the children of this section.
+        """
         out = []
         cnt = 0
         for child in self.children:
@@ -412,19 +425,34 @@ class SectionBlock(GenericBlock):
         return out
 
 class DummySectionBlock(SectionBlock):
+    """
+    Dummy section to be created at the start of each file (unless in strict
+    mode). This dummy section will print without section headings or its own
+    table of contents line. Otherwise it acts like a normal section block
+    """
+
     def __init__(self, origin, parent=None):
         super().__init__("Dummy", "", "", origin, parent=parent)
 
     def get_markdown(self, controller):
+        """
+        Returns the markdown for the dummy section. This is just the markdown
+        of the children.
+        """
         out = []
         if len (self.children > 0):
             out.append("---")
             out.append("")
-            out += self.get_childrens_mardown(controller)
+            out += self.get_childrens_markdown(controller)
 
         return out
 
     def get_toc_lines(self):
+        """
+        Returns the table of contents lines for the dummy section.
+        The indent is set to zero so that the bullet points are not
+        interpreted as a code block.
+        """
         return super().get_toc_lines(indent=0)
 
 class ItemBlock(LabelBlock):


### PR DESCRIPTION
This introduces a strict mode where openscad-docsgen functions as before. If strict is not enabled then modules can be documented without being in sections.

It would be good to do this for file blocks as well, but this would require a more significant refactoring of the code base which I though would require some conversation.

My two goals here are:
1. Make it easier to get started. Write a single module doc string, get a result
2. Make the documentation work as expected for files that are small enough that division into sections doesn't make sense.

Closes #3 
