### PR TITLE
Fix Size option

### DIFF
--- a/openscad_docsgen/imagemanager.py
+++ b/openscad_docsgen/imagemanager.py
@@ -49,6 +49,7 @@ class ImageRequest(object):
         m = self._size_re.search(image_meta)
         if m:
             self.imgsize = (int(m.group(1)), int(m.group(2)))
+            scale = 1.0
         elif "Small" in image_meta:
             scale = 0.75
         elif "Med" in image_meta:

--- a/openscad_docsgen/imagemanager.py
+++ b/openscad_docsgen/imagemanager.py
@@ -47,9 +47,9 @@ class ImageRequest(object):
             self.render_mode = RenderMode.render
 
         m = self._size_re.search(image_meta)
+        scale = 1.0
         if m:
             self.imgsize = (int(m.group(1)), int(m.group(2)))
-            scale = 1.0
         elif "Small" in image_meta:
             scale = 0.75
         elif "Med" in image_meta:
@@ -58,8 +58,6 @@ class ImageRequest(object):
             scale = 2.0
         elif "Huge" in image_meta:
             scale = 2.5
-        else:
-            scale = 1.0
         self.imgsize = [scale*x for x in self.imgsize]
 
         has_vp_splat = False


### PR DESCRIPTION
Specifying an image size caused Python to crash, I think it's a 1-line fix to initialise `scale`.