### PR TITLE
Assorted fixes

### DIFF
--- a/openscad_docsgen/__init__.py
+++ b/openscad_docsgen/__init__.py
@@ -20,6 +20,7 @@ def processFiles(
     gen_index=False,
     gen_topics=False,
     gen_cheat=False,
+    project_name=None,
     report=False,
     dump_tree=False,
     quiet=False
@@ -57,7 +58,7 @@ def processFiles(
     if gen_topics:
         docsgen.write_topics_file()
     if gen_cheat:
-        docsgen.write_cheatsheet_file()
+        docsgen.write_cheatsheet_file(project_name)
 
     if report:
         errorlog.write_report()
@@ -89,6 +90,8 @@ def main():
                         help='If given, generate TOC.md table of contents file.')
     parser.add_argument('-c', '--gen-cheat', action="store_true",
                         help='If given, generate CheatSheet.md file with all Usage lines.')
+    parser.add_argument('-P', '--project-name',
+                        help='If given, sets the name of the project to be shown in titles.')              
     parser.add_argument('-r', '--report', action="store_true",
                         help='If given, write all warnings and errors to docsgen_report.json')
     parser.add_argument('-d', '--dump-tree', action="store_true",
@@ -109,6 +112,7 @@ def main():
             gen_index=args.gen_index,
             gen_topics=args.gen_topics,
             gen_cheat=args.gen_cheat,
+            project_name=args.project_name,
             report=args.report,
             dump_tree=args.dump_tree,
             quiet=args.quiet

--- a/openscad_docsgen/blocks.py
+++ b/openscad_docsgen/blocks.py
@@ -1438,11 +1438,14 @@ class DocsGenParser(object):
             for line in out:
                 f.write(line + "\n")
 
-    def write_cheatsheet_file(self):
+    def write_cheatsheet_file(self, project_name=None):
         """Generates the CheatSheet.md file from the parsed documentation."""
         os.makedirs(self.docs_dir, mode=0o744, exist_ok=True)
         out = []
-        out.append("# The BOSL2 Cheat Sheet")
+        if project_name is None:
+            out.append("# Cheat Sheet")
+        else:
+            out.append("# The {} Cheat Sheet".format(project_name))
         out.append("")
         pri_blocks = self._files_prioritized()
         for file_block in pri_blocks:


### PR DESCRIPTION
Four commits:

1. `-D` option was not functioning
2. cheatsheet was generating with index on `-i` rather than when `-c` selected
3. A regex was not a raw string and had `\` characters in it
4. Adding `--project-name` or `-P` option so that you can set the name of your project. This is used in the cheat sheet rather than always using BOSL2