### PR TITLE
Fixes for scad files in directories, option to add .md to links

### DIFF
--- a/openscad_docsgen/__init__.py
+++ b/openscad_docsgen/__init__.py
@@ -23,7 +23,8 @@ def processFiles(
     project_name=None,
     report=False,
     dump_tree=False,
-    quiet=False
+    quiet=False,
+    md_in_links=False
 ):
     fail = False
     for infile in files:
@@ -39,7 +40,7 @@ def processFiles(
     if fail:
         sys.exit(-1)
 
-    docsgen = DocsGenParser(docs_dir=docs_dir, strict=strict, quiet=quiet)
+    docsgen = DocsGenParser(docs_dir=docs_dir, strict=strict, quiet=quiet, md_in_links=md_in_links)
     docsgen.parse_files(
         files, False,
         images=gen_imgs and gen_md,
@@ -96,6 +97,9 @@ def main():
                         help='If given, write all warnings and errors to docsgen_report.json')
     parser.add_argument('-d', '--dump-tree', action="store_true",
                         help='If given, dumps the documentation tree for debugging.')
+    parser.add_argument('--md-in-links', action="store_true",
+                        help=('If given, links to markdown pages will end with .md, this is'
+                              ' not needed if using in a GitHub wiki'))
     parser.add_argument('srcfile', nargs='+', help='List of input source files.')
     args = parser.parse_args()
 
@@ -115,7 +119,8 @@ def main():
             project_name=args.project_name,
             report=args.report,
             dump_tree=args.dump_tree,
-            quiet=args.quiet
+            quiet=args.quiet,
+            md_in_links=args.md_in_links
         )
 
     except DocsGenException as e:

--- a/openscad_docsgen/__init__.py
+++ b/openscad_docsgen/__init__.py
@@ -24,7 +24,8 @@ def processFiles(
     report=False,
     dump_tree=False,
     quiet=False,
-    md_in_links=False
+    md_in_links=False,
+    pure_md_images=False
 ):
     fail = False
     for infile in files:
@@ -40,7 +41,7 @@ def processFiles(
     if fail:
         sys.exit(-1)
 
-    docsgen = DocsGenParser(docs_dir=docs_dir, strict=strict, quiet=quiet, md_in_links=md_in_links)
+    docsgen = DocsGenParser(docs_dir=docs_dir, strict=strict, quiet=quiet, md_in_links=md_in_links, pure_md_images=pure_md_images)
     docsgen.parse_files(
         files, False,
         images=gen_imgs and gen_md,
@@ -100,6 +101,8 @@ def main():
     parser.add_argument('--md-in-links', action="store_true",
                         help=('If given, links to markdown pages will end with .md, this is'
                               ' not needed if using in a GitHub wiki'))
+    parser.add_argument('--pure-md-images', action="store_true",
+                        help=('If given, Images and examples will be pure markdown not HTML'))
     parser.add_argument('srcfile', nargs='+', help='List of input source files.')
     args = parser.parse_args()
 
@@ -120,7 +123,8 @@ def main():
             report=args.report,
             dump_tree=args.dump_tree,
             quiet=args.quiet,
-            md_in_links=args.md_in_links
+            md_in_links=args.md_in_links,
+            pure_md_images=args.pure_md_images
         )
 
     except DocsGenException as e:

--- a/openscad_docsgen/blocks.py
+++ b/openscad_docsgen/blocks.py
@@ -211,7 +211,7 @@ class TopicsBlock(LabelBlock):
     def get_markdown(self, controller):
         links = ", ".join("[{0}](Topics#{1})".format(mkdn_esc(topic),header_link(topic)) for topic in self.topics)
         out = []
-        out.append("**{}:** {}".format(mkdn_esc(self.title), mkdn_esc(links)))
+        out.append("**{}:** {}".format(mkdn_esc(self.title), links))
         out.append("")
         return out
 
@@ -231,9 +231,9 @@ class SeeAlsoBlock(LabelBlock):
                 item = controller.items_by_name[name]
                 if item is not self.parent:
                     items.append( item )
-        links = ", ".join( item.get_link(currfile=self.origin.file) for item in items )
+        links = ", ".join( item.get_link(currfile=self.origin.file, literalize=False) for item in items )
         out = []
-        out.append("**{}:** {}".format(mkdn_esc(self.title), mkdn_esc(links)))
+        out.append("**{}:** {}".format(mkdn_esc(self.title), links))
         out.append("")
         return out
 

--- a/openscad_docsgen/blocks.py
+++ b/openscad_docsgen/blocks.py
@@ -179,7 +179,7 @@ class GenericBlock(object):
                 out.append(self.parse_links(line, controller))
         return out
 
-    def get_markdown(self, controller):
+    def get_markdown(self, controller, pure_md=False):
         out = []
         out.append("**{}:** {}".format(mkdn_esc(self.title), mkdn_esc(self.subtitle)))
         out.extend(self.get_markdown_body(controller))
@@ -208,7 +208,7 @@ class TopicsBlock(LabelBlock):
         self.topics = [x.strip() for x in subtitle.split(",")]
         parent.topics = self.topics
 
-    def get_markdown(self, controller):
+    def get_markdown(self, controller, pure_md=False):
         links = ", ".join("[{0}](Topics#{1})".format(mkdn_esc(topic),header_link(topic)) for topic in self.topics)
         out = []
         out.append("**{}:** {}".format(mkdn_esc(self.title), links))
@@ -220,7 +220,7 @@ class SeeAlsoBlock(LabelBlock):
     def __init__(self, title, subtitle, body, origin, parent=None):
         super().__init__(title, subtitle, body, origin, parent=parent)
 
-    def get_markdown(self, controller):
+    def get_markdown(self, controller, pure_md=False):
         names = [name.strip() for name in self.subtitle.split(",")]
         items = []
         for name in names:
@@ -250,7 +250,7 @@ class BulletListBlock(GenericBlock):
     def __init__(self, title, subtitle, body, origin, parent=None):
         super().__init__(title, subtitle, body, origin, parent=parent)
 
-    def get_markdown(self, controller):
+    def get_markdown(self, controller, pure_md=False):
         out = []
         out.append("**{}:** {}".format(mkdn_esc(self.title), mkdn_esc(self.subtitle)))
         out.append("")
@@ -264,7 +264,7 @@ class NumberedListBlock(GenericBlock):
     def __init__(self, title, subtitle, body, origin, parent=None):
         super().__init__(title, subtitle, body, origin, parent=parent)
 
-    def get_markdown(self, controller):
+    def get_markdown(self, controller, pure_md=False):
         out = []
         out.append("**{}:** {}".format(mkdn_esc(self.title), mkdn_esc(self.subtitle)))
         out.append("")
@@ -286,7 +286,7 @@ class TableBlock(GenericBlock):
         if tnum >= len(self.header_sets):
             raise DocsGenException(title, "More tables than header_sets, while declaring block:")
 
-    def get_markdown(self, controller):
+    def get_markdown(self, controller, pure_md=False):
         prev_tnum = -1
         tnum = 0
         table = []
@@ -382,18 +382,18 @@ class FileBlock(GenericBlock):
             out.append("")
         return out
 
-    def get_markdown(self, controller):
+    def get_markdown(self, controller, pure_md=False):
         out = []
         out.append("# {}".format(mkdn_esc(str(self))))
         out.extend(self.get_markdown_body(controller))
         out.append("")
         for child in self.children:
             if not isinstance(child, SectionBlock):
-                out.extend(child.get_markdown(controller))
+                out.extend(child.get_markdown(controller, pure_md=pure_md))
         out.extend(self.get_toc_lines())
         for child in self.children:
             if isinstance(child, SectionBlock):
-                out.extend(child.get_markdown(controller))
+                out.extend(child.get_markdown(controller, pure_md=pure_md))
         return out
 
 
@@ -403,7 +403,7 @@ class IncludesBlock(GenericBlock):
         if parent:
             parent.includes.extend(body)
 
-    def get_markdown(self, controller):
+    def get_markdown(self, controller, pure_md=False):
         out = []
         if self.body:
             out.append("To use, add the following lines to the beginning of your file:")
@@ -431,7 +431,7 @@ class SectionBlock(GenericBlock):
                 out.append(" " * indent + child_link)
         return out
 
-    def get_markdown(self, controller):
+    def get_markdown(self, controller, pure_md=False):
         """
         Return the markdown for this section. This includes the section
         heading and the markdown for the children.
@@ -445,7 +445,7 @@ class SectionBlock(GenericBlock):
             out.append("")
         cnt = 0
         for child in self.children:
-            chout = child.get_markdown(controller)
+            chout = child.get_markdown(controller, pure_md=pure_md)
             if chout:
                 cnt += 1
             if cnt > 1:
@@ -507,7 +507,7 @@ class ItemBlock(LabelBlock):
         d["children"] = list(filter(lambda x: x["name"] not in skip_titles, d["children"]))
         return d
 
-    def get_markdown(self, controller):
+    def get_markdown(self, controller, pure_md=False):
         front_blocks = [
             ["Alias"],
             ["Aliases"],
@@ -523,7 +523,7 @@ class ItemBlock(LabelBlock):
         out.append("### {}".format(mkdn_esc(str(self))))
         out.append("")
         for child in self.sort_children(front_blocks, back_blocks):
-            out.extend(child.get_markdown(controller))
+            out.extend(child.get_markdown(controller, pure_md=pure_md))
         return out
 
 
@@ -628,40 +628,71 @@ class ImageBlock(GenericBlock):
         sys.stderr.flush()
         errorlog.add_entry(req.src_file, req.src_line, out, ErrorLog.FAIL)
 
-    def get_markdown(self, controller):
+    def get_markdown(self, controller, pure_md=False):
         fileblock = self.parent
         while fileblock.parent:
             fileblock = fileblock.parent
         out = []
         if "Hide" in self.meta:
             return out
-        out.append("<br/>")
+
+        #Add Example/Figure title
+        if not pure_md:
+            out.append("<br/>")
         out.append("")
         out.append("**{}:** {}".format(mkdn_esc(self.title), mkdn_esc(self.subtitle)))
         out.append("")
-        if "NORENDER" not in self.meta and self.image_url:
-            out.append(
-                '<img align="left" alt="{0} {1}" src="{2}">'
-                .format(
-                    mkdn_esc(self.parent.subtitle),
-                    mkdn_esc(self.title),
-                    self.image_url_rel
-                )
-            )
-            out.append("")
+
         if "Figure" in self.title:
-            out.append('<br clear="all" />')
+            out.extend(self._get_image_markdown(pure_md))
+            if not pure_md:
+                out.append('<br clear="all" />')
             out.append("")
         else:
+            # Example.
+            # In example in pure markdown image is after code block
+            if not pure_md:
+                out.extend(self._get_image_markdown(pure_md))
             if self.image_req and self.image_req.script_under:
-                out.append('<br clear="all" />')
+                if not pure_md:
+                    out.append('<br clear="all" />')
                 out.append("")
-            out.extend(["    " + line for line in fileblock.includes])
-            out.extend(["    " + line for line in self.body if not line.strip().startswith("--")])
+            #Currently Pure markdown used fenced code. This should probably be configurable
+            out.extend(self._get_example_markdown(fileblock, fence_code=pure_md))
             out.append("")
             if not self.image_req or not self.image_req.script_under:
-                out.append('<br clear="all" />')
+                if not pure_md:
+                    out.append('<br clear="all" />')
                 out.append("")
+            if pure_md:
+                out.extend(self._get_image_markdown(pure_md))
+        return out
+
+    def _get_image_markdown(self, pure_md=False):
+        out = []
+        if "NORENDER" not in self.meta and self.image_url:
+            img_data = [mkdn_esc(self.parent.subtitle),
+                        mkdn_esc(self.title),
+                        self.image_url_rel]
+            if pure_md:
+                out.append('![{0} {1}]({2} "{0} {1}")'.format(*img_data))
+            else:
+                out.append(
+                    '<img align="left" alt="{0} {1}" src="{2}">'.format(*img_data)
+                )
+            out.append("")
+        return out
+
+    def _get_example_markdown(self, fileblock, fence_code=False):
+        out = []
+        if fence_code:
+            out.append("``` {.C linenos=True}")
+            out.extend([line for line in fileblock.includes])
+            out.extend([line for line in self.body if not line.strip().startswith("--")])
+            out.append("```")
+        else:
+            out.extend(["    " + line for line in fileblock.includes])
+            out.extend(["    " + line for line in self.body if not line.strip().startswith("--")])
         return out
 
 
@@ -720,11 +751,12 @@ class DocsGenParser(object):
     RCFILE = ".openscad_gendocs_rc"
     HASHFILE = ".source_hashes"
 
-    def __init__(self, docs_dir="docs", strict=False, quiet=False, md_in_links=False):
+    def __init__(self, docs_dir="docs", strict=False, quiet=False, md_in_links=False, pure_md_images=False):
         self.docs_dir = docs_dir.rstrip("/")
         self.strict = strict
         self.quiet = quiet
         self.md_in_links = md_in_links
+        self.pure_md_images = pure_md_images
         self.file_blocks = []
         self.curr_file_block = None
         self.curr_section = None
@@ -1292,7 +1324,7 @@ class DocsGenParser(object):
         """
         if testonly:
             for fblock in self.file_blocks:
-                lines = fblock.get_markdown(self)
+                lines = fblock.get_markdown(self, pure_md=self.pure_md_images)
             return
         os.makedirs(self.docs_dir, mode=0o744, exist_ok=True)
         for fblock in self.file_blocks:
@@ -1304,7 +1336,7 @@ class DocsGenParser(object):
             if not os.path.exists(outdir):
                 os.makedirs(outdir, mode=0o744, exist_ok=True)
             with open(outfile,"w") as f:
-                for line in fblock.get_markdown(self):
+                for line in fblock.get_markdown(self, pure_md=self.pure_md_images):
                     f.write(line + "\n")
 
     def write_toc_file(self):


### PR DESCRIPTION
In the openflexure microscope we have our openscad code in directories this causes issues as some parts of `openscad-docgen` refer to the full path, but the file was only output based on the file name. Also we do not plan to put our documentation on a github wiki which means that some things need to be tweakable.

This pull will do:
* [x] Sets the output of `directory/file.scad` to `docs/directory/file.scad.md` rather than `docs/file.scad.md`
* [x] Makes images from`directory/file.scad` go to `docs/directory/images/file/function.png` rather than `docs/images/file/function.png` - This was chosen instead images being in `docs/images` because to do that the relative links from the files inside directories becomes annoying.
* [x] Give an option for the link to `docs/file.scad.md` to explicitly include the `.md`. This option is off as default
* [x] Give  an option for image blocks to use standard markdown image syntax
* [x] Use fenced code for examples - This is currently set to be on only when using pure markdown images.

Note that when doing the pure markdown images I have reversed the order of the code and image:
![image](https://user-images.githubusercontent.com/12807051/139483101-06de5d9a-1dd8-48dc-bbca-e146c5f8d647.png)
