### PR TITLE
Support Color Schemes in Example & Figure Blocks

### DIFF
--- a/WRITING_DOCS.md
+++ b/WRITING_DOCS.md
@@ -724,6 +724,11 @@ metadata directives:
 - `Edges`: Highlight face edges.
 - `NoAxes`: Hides the axes and scales.
 - `ScriptUnder`: Display script text under image, rather than beside it.
+- `ColorScheme`: Generate the image using a specific color scheme
+  - Usage: `ColorScheme=<color scheme name>` (e.g. `ColorScheme=BeforeDawn`)
+  - Default color scheme: `Cornfield`
+  - Predefined color schemes: `Cornfield`, `Metallic`, `Sunset`, `Starnight`, `BeforeDawn`, `Nature`, `DeepOcean`, `Solarized`, `Tomorrow`, `Tomorrow Night`, `Monotone`
+  - Color schemes defined as a [Read-only Resource](https://github.com/openscad/openscad/wiki/Path-locations#read-only-resources) or [User Resource](https://github.com/openscad/openscad/wiki/Path-locations#user-resources) are also supported.
 
 Modules will default to generating and displaying the image as if the `3D`
 directive is given.  Functions and constants will default to not generating


### PR DESCRIPTION
## Included Changes
* Add support for color scheme specification in `Example` and `Figure` blocks
  * Color scheme is defined via the `ColorScheme=<color scheme name>` metadata directive  
  * Default color scheme is `Cornfield`
  * Supports all predefined, read-only resource, and user resource color schemes
* This change was manually tested with all predefined color schemes, the default color scheme, and a user resource color scheme. 

## Are there any changes that require more careful review?
* Should the `ColorScheme` enum from `openscad_runner` be used?
  * `OpenScadRunner` doesn't require the usage of the enum, and acceps the color scheme name as a string. And, the color scheme name can be any arbitrary value (to support schemes defined outside the predefined set). So, the only thing it's being used for is getting the value of the default color scheme name. If there's a desire to minimize coupling with `openscad_runner`, the string literal can be used to define the default value instead.

## Screenshots/Examples

### Default color scheme

```openscad
// Example(3D):
//   cube(3);
```

![test-default](https://user-images.githubusercontent.com/9967779/228535972-32752b84-1128-4e8d-9cc6-6684113110ad.png)

### Predefined color scheme

```openscad
// Example(3D,ColorScheme=Tomorrow Night):
//   cube(3);
```
![test-predfined](https://user-images.githubusercontent.com/9967779/228536838-ab5f33a1-7efb-4b77-a032-a7120f5b67c7.png)

### User resource color scheme
Note: This is a duplicate of `Tomorrow Night` color scheme with the background set to white and named `Tomorrow Night White BG`

```openscad
// Example(3D,ColorScheme=Tomorrow Night White BG):
//   cube(3);
```

![test-user-resource](https://user-images.githubusercontent.com/9967779/228538240-f4a8bd81-a78d-4d23-b8a6-02b5866a129b.png)
